### PR TITLE
feat(register route): implement route to register candidate [#163776587]

### DIFF
--- a/src/controllers/candidateController.js
+++ b/src/controllers/candidateController.js
@@ -1,0 +1,48 @@
+import pdb from '../model/query';
+
+class CandidateController {
+  static createCandidate(req, res) {
+    const { candidateName } = req.body;
+    const userId = parseInt(req.params.userId, 10);
+    const officeId = parseInt(req.body.officeId, 10);
+    const partyId = parseInt(req.body.partyId, 10);
+    const candidateId = parseInt(req.body.candidateId, 10);
+    const userQueryText = 'SELECT * FROM users WHERE id = $1';
+    const userParam = [userId];
+    pdb(userQueryText, userParam, (err, result) => {
+      if (result.rowCount === 0) {
+        res.status(400).json('no user');
+      } else {
+        const queryOffice = 'SELECT * FROM offices WHERE id = $1';
+        const paramOffice = [officeId];
+        pdb(queryOffice, paramOffice, (err, result) => {
+          if (result.rowCount === 0) {
+            res.status(400).json('no such office');
+          } else {
+            const text2 = 'INSERT INTO candidates (candidateName, userId, partyId, officeId, candidateId) VALUES ($1,$2,$3,$4,$5) RETURNING *';
+            const param2 = [candidateName, userId, partyId, officeId, candidateId];
+            pdb(text2, param2, (err, result) => {
+              if (err) {
+                if (err.detail === `Key (officeid, userid)=(${officeId}, ${userId}) already exists.`) {
+                  res.json({
+                    status: 401,
+                    error: 'you already registered candidate',
+                  });
+                } else {
+                  res.json({
+                    status: 401,
+                    error: err.message,
+                  });
+                }
+              } else {
+                res.json(result.rows[0]);
+              }
+            });
+          }
+        });
+      }
+    });
+  }
+}
+
+export default CandidateController;

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -59,7 +59,7 @@ class UserController {
     try {
       const {
         email,
-        password
+        password,
       } = req.body;
       const text = 'SELECT * FROM users WHERE email = $1';
       const param = [email];
@@ -72,11 +72,10 @@ class UserController {
           // eslint-disable-next-line no-lonely-if
           if (passwordHash.verify(password, result.rows[0].hashedpassword)) {
             const user = {
-              firstname: result.rows[0].firstname,
-              email: result.rows[0].email,
-              id: result.rows[0].id,
+              isAdmin: result.rows[0].isadmin,
             };
-            jwt.sign({ user }, 'secretekey', (err, token) => {
+            console.log(result.rows[0].isadmin,'GERGER')
+            jwt.sign(user, process.env.SECRETE_KEY, (err, token) =>{
               const response = {
                 status: 200,
                 data: [{

--- a/src/helpers/candidateValidator.js
+++ b/src/helpers/candidateValidator.js
@@ -1,0 +1,44 @@
+
+class CandidateValidators {
+
+  static validateCandidate(req, res, next) {
+    const { candidateName } = req.body;
+    const userId = parseInt(req.params.userId, 10);
+    const officeId = parseInt(req.body.officeId, 10);
+    const partyId = parseInt(req.body.partyId, 10);
+    const candidateId = parseInt(req.body.candidateId, 10);
+    //
+    const errorKeyMessage = 'missing a name key';
+    try {
+      const keys = Object.keys(req.body);
+      if (!(keys.includes('candidateName'))
+            || !(keys.includes('officeId'))
+            || !(keys.includes('partyId'))
+            || !(keys.includes('candidateId'))) {
+        throw new Error(errorKeyMessage);
+      } else if (isNaN(req.params.userId) || isNaN(req.body.officeId)
+            || isNaN(req.body.partyId) || isNaN(req.body.candidateId)) {
+        throw new ('input must be number ...userId, officeId, candiateId')();
+      } else if (candidateName === '' || officeId === '' || userId === ''
+          || partyId === '' || candidateId === '') {
+        throw new Error('no input field should be empty');
+      } else if (isNaN(partyId)
+      || isNaN(officeId)
+      || isNaN(candidateId)) {
+        throw new Error('inputs should be numbers ..partyId, officeId, candidateId');
+      } else {
+        next();
+      }
+    } catch (err) {
+      const response = {
+        status: 400,
+        error: `${err} `,
+      };
+      res.json(response);   
+    }
+    //
+  }
+
+}
+
+export default CandidateValidators;

--- a/src/helpers/userAuth.js
+++ b/src/helpers/userAuth.js
@@ -9,7 +9,7 @@ const verifyToken = (req, res, next) => {
     req.token = bearerToken;
     console.log(req.token);
     jwt.verify(req.token, process.env.SECRETE_KEY, (err, result) => {
-        console.log(err);
+      console.log(err);
       if (err) res.status(401).json('unauthorised2');
       else {
         req.result = result.isAdmin;

--- a/src/helpers/userValidator.js
+++ b/src/helpers/userValidator.js
@@ -11,13 +11,37 @@ class UserValidators {
       phoneNumber,
       passportUrl,
     } = req.body;
-    if (firstName.trim() === '' || lastName.trim() === '' || otherName.trim() === ''
+    //
+    const errorKeyMessage = 'missing a name key';
+    try {
+      const keys = Object.keys(req.body);
+      if (!(keys.includes('firstName')) || 
+      !(keys.includes('lastName')) ||
+      !(keys.includes('otherName')) ||
+      !(keys.includes('email')) ||
+      !(keys.includes('password')) ||
+      !(keys.includes('passportUrl')) ||
+      !(keys.includes('phoneNumber'))) {
+        throw new Error(errorKeyMessage);
+      }
+      else if (firstName.trim() === '' || lastName.trim() === '' || otherName.trim() === ''
     || email.trim() === '' || password.trim() === '' || phoneNumber.trim() === ''
     || passportUrl.trim() === '') {
-      res.status(400).json('no input field should be empty');
-    } else {
-      next();
+        throw new Error('no input field should be empty');
+      } else if (!(email.trim().includes('@')) || !(email.trim().endsWith('.com'))) {
+        throw new Error('improper email format');
+      }
+      else {
+        next();
+      }
+    } catch (err) {
+      const response = {
+        status: 400,
+        error: `${err} input should have firstName, lastName, otherName, email, password, phoneNumber, passportUrl`,
+      };
+      res.json(response);   
     }
+    //
   }
 
   static validateUserlogin(req, res, next) {
@@ -25,11 +49,28 @@ class UserValidators {
       email,
       password,
     } = req.body;
-    if (email.trim() === '' || password.trim() === '') {
-      res.status(400).json('no input field should be empty');
-    } else {
-      next();
+    //
+    const errorKeyMessage = 'missing a name key';
+    try {
+      const keys = Object.keys(req.body);
+      if (!(keys.includes('email'))
+      || !(keys.includes('password'))) {
+        throw new Error(errorKeyMessage);
+      } else if (email.trim() === '' || password.trim() === '') {
+        throw new Error('no input field should be empty');
+      } else if (!(email.trim().includes('@')) || !(email.trim().endsWith('.com'))) {
+        throw new Error('improper email format');
+      } else {
+        next();
+      }
+    } catch (err) {
+      const response = {
+        status: 400,
+        error: `${err} input should have firstName, lastName, otherName, email, password, phoneNumber, passportUrl`,
+      };
+      res.json(response);   
     }
+    //
   }
 }
 

--- a/src/model/migrations.js
+++ b/src/model/migrations.js
@@ -25,8 +25,17 @@ const userTable = `CREATE TABLE IF NOT EXISTS users (
     isAdmin BOOLEAN DEFAULT false
 );`; 
 
+const candidateTable = `CREATE TABLE IF NOT EXISTS candidates (
+     id serial,
+     candidateName VARCHAR(100) NOT NULL,
+     userId integer NOT NULL,
+     partyId integer NOT NULL,
+     officeId integer NOT NULL,
+    candidateId integer NOT NULL,
+    PRIMARY KEY (officeId, userId)
+);`;
 const createTables = () => {
-  pdb(`${officeTable} ${partyTable} ${userTable}`, ()=>{
+  pdb(`${officeTable} ${partyTable} ${userTable} ${candidateTable}`, ()=>{
     console.log('table created');
   })
 };

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -7,6 +7,9 @@ import OfficeController from '../controllers/officeController';
 import OfficeValidators from '../helpers/officeValidator';
 import UserController from '../controllers/userController';
 import verifyToken from '../helpers/userAuth';
+import CandidateController from '../controllers/candidateController';
+import CandidateValidators from '../helpers/candidateValidator';
+
 
 const { validateCreateParty, validateEditNameOfParty, validateDeleteParty } = PartyValidators; 
 const { createParty, getSpecificParty, getAllParties, editPartyName, deletePartyName } = PartyController; 
@@ -14,6 +17,8 @@ const { validateCreateOffice } = OfficeValidators;
 const { createOffice, getAllOffices, getSpecificOffice } = OfficeController;
 const { signUp, login } = UserController;
 const { validateUserSignup, validateUserlogin } = UserValidator;
+const { createCandidate } = CandidateController;
+const { validateCandidate } = CandidateValidators;
 const route = express.Router();
 route.post('/parties', validateCreateParty, createParty);
 route.get('/parties/:partyId', getSpecificParty);
@@ -25,6 +30,7 @@ route.get('/offices', getAllOffices);
 route.get('/offices/:officeId', getSpecificOffice);
 route.post('/auth/signup', validateUserSignup, signUp);
 route.post('/auth/login', validateUserlogin, login);
+route.post('/office/:userId/register', validateCandidate, createCandidate);
 // challenge 2 completed
 
 export default route;


### PR DESCRIPTION
#### What does this PR do?
It allows the Admin to register a user as a candidate for a political office
#### Description of Task to be completed?
Have the endpoint working

- POST api/v1/office/officeId/register
#### How should this be manually tested?
after cloning the repo, cd into it, run 'npm i' and type npm run test.
The endpoint can also be tested using Postman or your browser
Navigate to the above route. 
you should get the particular office associated with the id.
if office is not found, it should respond as office not found.
if keys are incomplete, it should return and error of 'improper key'
#### Any background context you want to provide?
Not yet
#### What are the relevant pivotal tracker stories?
#163776587
#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/42284402/52422956-6a497b00-2af7-11e9-8459-4f226462978f.png)

#### Questions:
none